### PR TITLE
Download resulting file after template conversion

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,7 +22,7 @@ Local Setup
 - `node server/index.js`
 - Optional: `DEVELOPMENT=true node server/index.js` for logging.
 ```
-POST to: http://localhost:3000/generate-file
+POST to: http://localhost:5000/generate-file
 BODY: 
 {
     "template": "test-template.js",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liwg-backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Backend for LIWG",
   "main": "index.js",
   "dependencies": {

--- a/backend/server/index.js
+++ b/backend/server/index.js
@@ -1,9 +1,8 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const app = express();
-const port = 3000;
+const port = 5000;
 var cors = require('cors');
-
 let converter = require('../template-generation/generate-source-file.js');
 
 app.use(cors());
@@ -14,13 +13,17 @@ app.use(
     })
 )
 
-/**
- * Pass the template name in request.headers.template
- * Example to run the test file: "key: test-template.js"
- */
 app.post('/generate-file', (request, response) => {
-    converter.convertTemplate(request.headers.template, request.body);
-    response.json({ info: 'Node.js, Express, and O-Auth' })
+    converter.convertTemplate(request.body)
+    .then(file => {
+        response.download(file, (err) => {
+            if (err) console.log('Error downloading file: ', err)
+        });
+    })
+    .catch(error => {
+        console.log('Error: ', error);
+        response.json({ error: error })
+    })
 })
 
 app.listen(port, () => {

--- a/backend/server/index.js
+++ b/backend/server/index.js
@@ -24,7 +24,7 @@ app.post('/generate-file', (request, response) => {
     })
     .catch(error => {
         console.log('Error: ', error);
-        response.json({ error: error })
+        response.json({ error: error });
     })
 });
 

--- a/backend/server/index.js
+++ b/backend/server/index.js
@@ -6,26 +6,28 @@ var cors = require('cors');
 let converter = require('../template-generation/generate-source-file.js');
 
 app.use(cors());
-app.use(bodyParser.json())
+app.use(bodyParser.json());
 app.use(
     bodyParser.urlencoded({
         extended: true,
     })
-)
+);
 
 app.post('/generate-file', (request, response) => {
     converter.convertTemplate(request.body)
     .then(file => {
         response.download(file, (err) => {
-            if (err) console.log('Error downloading file: ', err)
+            if (err) {
+                console.log('Error downloading file: ', err);
+            }
         });
     })
     .catch(error => {
         console.log('Error: ', error);
         response.json({ error: error })
     })
-})
+});
 
 app.listen(port, () => {
     console.log(`App running on port ${port}.`)
-})
+});

--- a/backend/template-generation/generate-source-file.js
+++ b/backend/template-generation/generate-source-file.js
@@ -1,7 +1,6 @@
 let Handlebars = require('handlebars');
 let fs = require('fs');
 const filePath = process.env.TEMPLATE_PATH || __dirname + '/test/';
-const logger = process.env.DEVELOPMENT || false;
 
 function readFile(file) {
     return new Promise((resolve, reject) => {
@@ -25,19 +24,16 @@ function readFile(file) {
  *  Note: data.template is a required attribue of the JSON object
  */
 exports.convertTemplate = function (data) {
-    if (!data.template) console.log('Error: No template provided.')
-    readFile(filePath + data.template).then(template => { 
-        if (logger) {
-            console.log('Template ===> ', template);
-            console.log('Data ===> ', JSON.stringify(data));
-        }
+    return new Promise((resolve, reject) => {
+        if (!data.template) reject('No template provided.')
+        readFile(filePath + data.template).then(template => { 
+            template = Handlebars.compile(template);
+            result = template(data);
 
-        template = Handlebars.compile(template);
-        result = template(data);
-        if (logger) console.log('Conversion Result ===> ', result);
-
-        fs.writeFile(filePath + 'generated-file.js', result, function (err) {
-            if (err) throw err;
+            fs.writeFile(filePath + 'generated-file.js', result, function (err) {
+                if (err) reject(err);
+                resolve(filePath + 'generated-file.js')
+            });
         });
     });
 }

--- a/backend/template-generation/generate-source-file.js
+++ b/backend/template-generation/generate-source-file.js
@@ -37,7 +37,7 @@ exports.convertTemplate = function (data) {
                 if (err) {
                     reject(err);
                 }
-                resolve(filePath + 'generated-file.js')
+                resolve(filePath + 'generated-file.js');
             });
         });
     });

--- a/backend/template-generation/generate-source-file.js
+++ b/backend/template-generation/generate-source-file.js
@@ -28,7 +28,8 @@ exports.convertTemplate = function (data) {
         if (!data.template) {
             reject('No template provided.');
         }
-        readFile(filePath + data.template).then(template => { 
+        readFile(filePath + data.template)
+        .then(template => { 
             template = Handlebars.compile(template);
             result = template(data);
 

--- a/backend/template-generation/generate-source-file.js
+++ b/backend/template-generation/generate-source-file.js
@@ -25,13 +25,17 @@ function readFile(file) {
  */
 exports.convertTemplate = function (data) {
     return new Promise((resolve, reject) => {
-        if (!data.template) reject('No template provided.')
+        if (!data.template) {
+            reject('No template provided.');
+        }
         readFile(filePath + data.template).then(template => { 
             template = Handlebars.compile(template);
             result = template(data);
 
             fs.writeFile(filePath + 'generated-file.js', result, function (err) {
-                if (err) reject(err);
+                if (err) {
+                    reject(err);
+                }
                 resolve(filePath + 'generated-file.js')
             });
         });

--- a/backend/template-generation/test/test-template-generation.js
+++ b/backend/template-generation/test/test-template-generation.js
@@ -15,4 +15,10 @@ let data = {
     ]
 }
 
-converter.convertTemplate(data);
+converter.convertTemplate(data)
+.then((file) => {
+    console.log('Wrote converted template to: ', file);
+})
+.catch((error) => {
+    console.log(error);
+});


### PR DESCRIPTION
**Highlights:**
- Express `response.download` function added to tell the browser to download the file. 
- `convertTemplate` function returns a promise rather than taking a callback
- Fixed issue with template being in header
- Updated server to run on port `5000` to test submit post requests to `http://localhost:5000/generate-file`